### PR TITLE
Handle combatants that have no token.

### DIFF
--- a/scripts/CombatBooster.js
+++ b/scripts/CombatBooster.js
@@ -65,22 +65,22 @@ Hooks.on("updateCombat", function (combat, updates) {
     const token = canvas.tokens.get(combat.current.tokenId);
     if (game.settings.get("combatbooster", "panCamera")) {
       canvas.animatePan({
-        x: token.center.x,
-        y: token.center.y,
+        x: token?.center.x,
+        y: token?.center.y,
         duration: 300,
       });
     }
     if (game.settings.get("combatbooster", "controlToken")) {
       canvas.tokens.releaseAll();
-      token.control();
+      token?.control();
     }
     if (game.settings.get("combatbooster", "renderTokenHUD")) {
-      token.layer.hud.bind(token);
+      token?.layer.hud.bind(token);
     }
   }
   if(!game.user.isGM && "turn" in updates) {
     const token = canvas.tokens.get(combat.current.tokenId);
-    if (token.isOwner) {
+    if (token?.isOwner) {
       const soundPath = game.settings.get("combatbooster", "soundPath")
       if(soundPath){
         AudioHelper.play(

--- a/scripts/TurnMarker.js
+++ b/scripts/TurnMarker.js
@@ -69,8 +69,12 @@ class TurnMarker {
   }
 
   MoveToCombatant() {
-    const combatant = canvas.tokens.get(game.combat?.combatant?._token?._id);
-    if (combatant && this.id !== combatant.id) this.Move(combatant);
+    const token = canvas.tokens.get(game.combat?.combatant?.token?.id);
+    if (token && this.id !== token.id) {
+      this.Move(token);
+    } else if (!token) {
+      this.Destroy(true);
+    }
   }
 
   get tokenScale() {


### PR DESCRIPTION
Modifies the functions that retrieve a token from a combatant to account
for no token to be returned. In the case of the TurnMarker,
MoveToCombatant is changed to clear the marker in the case of an empty
token. The updateCombat hook is modified to use optional chaining,
ensuring that no errors are thrown if there's no token.

This improves compatibility with lancer-initiative, which uses a hidden
combatant at the beginning of the tracker to represent no turn
occurring.
